### PR TITLE
Improved documentation style for the 'Using different installation profile' page

### DIFF
--- a/docs/working-with-humpback/using-different-installation-profile.md
+++ b/docs/working-with-humpback/using-different-installation-profile.md
@@ -3,12 +3,12 @@
 Humpback by default create it's own installation profile, that profile is stored in profiles folder and its content is symlinked to the folder `web/profiles/custom`. This profile is used by default to install the site.
 If you want to override this behavior and use a different install profile (custom or contrib), you need to place that profile in the right folder (profiles/custom) or by adding it to the project using `composer require` and ensuring it gets placed under web/profiles/contrib and then make some small changes to ensure this profile gets used:
 
-- Remove all config files under config/sync to ensure profile config is used
+- Remove all config files under `config/sync` to ensure profile config is used
 - Change install profile on .ahoy/site.ahoy around **line 57**:
 ```bash
 ahoy drush site-install <profile_name> --account-pass=admin -y
 ```
-- Change install profile on settings/settings.php around **line 81**:
+- Change install profile on `settings/settings.php` around **line 81**:
 ```php
 $settings['install_profile'] = <profile_name>;
 ```

--- a/docs/working-with-humpback/using-different-installation-profile.md
+++ b/docs/working-with-humpback/using-different-installation-profile.md
@@ -4,10 +4,20 @@ Humpback by default create it's own installation profile, that profile is stored
 If you want to override this behavior and use a different install profile (custom or contrib), you need to place that profile in the right folder (profiles/custom) or by adding it to the project using `composer require` and ensuring it gets placed under web/profiles/contrib and then make some small changes to ensure this profile gets used:
 
 - Remove all config files under config/sync to ensure profile config is used
-- Change install profile on .ahoy/site.ahoy around line 57 `ahoy drush site-install <profile_name> --account-pass=admin -y`
-- Change install profile on settings/settings.php around line 81 `$settings['install_profile'] = <profile_name>;`
-- Change install profile in circleci build job install command around line 53 `../vendor/bin/drush si <profile_name>` (it's twice in the same line)
-- Change install profile in circleci deploy job install command around line 108 `terminus drush <profile_name>.dev -- si <profile_name> --account-pass=admin -y`
+- Change install profile on .ahoy/site.ahoy around **line 57**:
+```bash
+ahoy drush site-install <profile_name> --account-pass=admin -y
+```
+- Change install profile on settings/settings.php around **line 81**:
+```php
+$settings['install_profile'] = <profile_name>;
+```
+- Change install profile in circleci build job install command around **line 53** `../vendor/bin/drush si <profile_name>` (it's twice in the same line)
+- Change install profile in circleci deploy job install command around **line 108**:
+```bash
+terminus drush <profile_name>.dev -- si <profile_name> --account-pass=admin -y
+```
+
 
 And that's all!
 


### PR DESCRIPTION
Steps to test:
- Execute mkdocs serve and go to this page: `working-with-humpback/using-different-installation-profile/`
-  That page should looks like this: 
![captura de pantalla de 2018-10-01 11-34-52](https://user-images.githubusercontent.com/2217827/46305422-9c0d6c80-c56e-11e8-8e7b-719d80d32d1a.png)
