### PR TITLE
Docs for ahoy site install-from-db command.

### DIFF
--- a/docs/humpback-commands/ahoy-site-install-from-db.md
+++ b/docs/humpback-commands/ahoy-site-install-from-db.md
@@ -1,0 +1,12 @@
+# ahoy site install-from-db
+
+This command could be executed as many times as needed and it allows you to set up your local site based on a db backup.
+If you don't have a db backup yet, it will try to download one from the Pantheon live environment using Terminus. If you don't have an integration with Pantheon or you just want to supply the database backup manually, you'll have to put in the root directory of the project the compressed backup under the name `<your project name>.sql.gz`.
+This command will:
+
+- Get the compressed database backup if it doesn't exists.
+- Uncompress the backup and import it in the database.
+- Run database updates.
+- Import configuration.
+- Clear caches.
+- Sanitize the database.

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,6 +28,7 @@ This is the official documentation for the Humpback tool.
   - [ahoy down](humpback-commands/ahoy-down.md)
   - [ahoy site](humpback-commands/ahoy-site.md)
   - [ahoy site install](humpback-commands/ahoy-site-install.md)
+  - [ahoy site install-from-db](humpback-commands/ahoy-site-install-from-db.md)
   - [ahoy composer](humpback-commands/ahoy-composer.md)
   - [ahoy help](humpback-commands/ahoy-help.md)
   - [ahoy drush](humpback-commands/ahoy-drush.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,6 +29,7 @@ pages:
     - ahoy help: humpback-commands/ahoy-help.md
     - ahoy site: humpback-commands/ahoy-site.md
     - ahoy site install: humpback-commands/ahoy-site-install.md
+    - ahoy site install-from-db: humpback-commands/ahoy-site-install-from-db.md
     - ahoy drush: humpback-commands/ahoy-drush.md
     - ahoy bash: humpback-commands/ahoy-bash.md
     - ahoy docker: humpback-commands/ahoy-docker.md


### PR DESCRIPTION
Adds the documentation for `ahoy site install-from-db` command included in https://github.com/humpbackdev/generator-humpback/pull/82